### PR TITLE
add apiSuccessHeader & apiSuccessStatus

### DIFF
--- a/lib/filters/api_success_header.js
+++ b/lib/filters/api_success_header.js
@@ -1,0 +1,37 @@
+/**
+ * Post Filter parsed results
+ * Remove double fields, happen when overwrite a global inherited field with a local definition.
+ *
+ * @param {Object[]} parsedFiles
+ * @param {String[]} filenames
+ * @returns {Object}
+ */
+function postFilter(parsedFiles, filenames) {
+    parsedFiles.forEach(function(parsedFile) {
+        parsedFile.forEach(function(block) {
+            if (block.local.success && block.local.success.headers) {
+                var blockHeaders = block.local.success.headers;
+                Object.keys(blockHeaders).forEach(function(blockHeaderKey) {
+                    var headers = block.local.success.headers[blockHeaderKey];
+                    var newHeaders = [];
+                    var existingKeys = {};
+                    headers.forEach(function(header) {
+                        var key = header.field; // .field (=id) is the key to check if it exists twice
+                        if ( ! existingKeys[key]) {
+                            existingKeys[key] = 1;
+                            newHeaders.push(header);
+                        }
+                    });
+                    block.local.success.headers[blockHeaderKey] = newHeaders;
+                });
+            }
+        });
+    });
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    postFilter: postFilter
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,8 @@ var app = {
         apiparamexample          : './parsers/api_param_example.js',
         apipermission            : './parsers/api_permission.js',
         apisuccess               : './parsers/api_success.js',
+        apisuccessstatus         : './parsers/api_success_status.js',
+        apisuccessheader         : './parsers/api_success_header.js',
         apisuccessexample        : './parsers/api_success_example.js',
         apiuse                   : './parsers/api_use.js',
         apiversion               : './parsers/api_version.js',

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,8 @@ var app = {
         apierror                 : './filters/api_error.js',
         apiheader                : './filters/api_header.js',
         apiparam                 : './filters/api_param.js',
-        apisuccess               : './filters/api_success.js'
+        apisuccess               : './filters/api_success.js',
+        apisuccessheader         : './filters/api_success_header.js'
     },
     languages: {
         '.clj'                   : './languages/clj.js',

--- a/lib/parsers/api_success_header.js
+++ b/lib/parsers/api_success_header.js
@@ -1,0 +1,21 @@
+// Same as @apiParam
+var apiParser = require('./api_param.js');
+
+function parse(content, source) {
+    return apiParser.parse(content, source, 'Success 200');
+}
+
+function path() {
+    return 'local.success.headers.' + apiParser.getGroup();
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse         : parse,
+    path          : path,
+    method        : apiParser.method,
+    markdownFields: [ 'description', 'type' ],
+    markdownRemovePTags: [ 'type' ]
+};

--- a/lib/parsers/api_success_status.js
+++ b/lib/parsers/api_success_status.js
@@ -1,0 +1,86 @@
+var trim     = require('../utils/trim');
+var unindent = require('../utils/unindent');
+
+var group = '';
+
+// Search: group, type, description
+// Example: (200) {text/plain} Description content
+//
+// Naming convention:
+//     b -> begin
+//     e -> end
+//     name -> the field value
+//     oName -> wrapper for optional field
+//     wName -> wrapper for field
+var regExp = {
+    b:               '^',                                   // start
+    wStatus: {                                               // status code (group): (404)
+        b:               '\\s*(?:\\(\\s*',                  // starting with '(', optional surrounding spaces
+        group:              '(.+)',                        // 1
+        e:               '\\s*\\)\\s*)?'                    // ending with ')', optional surrounding spaces
+    },
+    oType: {                                                // optional response type: {text/plain}, {empty}
+        b:               '\\s*(?:\\{\\s*',                  // starting with '{', optional surrounding spaces
+        type:                '([a-zA-Z0-9\(\)#:\\.\\/\\\\\\[\\]_-]+)', // 2
+        e:               '\\s*\\}\\s*)?'                    // ending with '}', optional surrounding spaces
+    },
+    oDescription:         '(.*)?',                           // 3
+    e:               '$|@'
+};
+
+function _objectValuesToString(obj) {
+    var str = '';
+    for (var el in obj) {
+        if (typeof obj[el] === 'string')
+            str += obj[el];
+        else
+            str += _objectValuesToString(obj[el]);
+    }
+    return str;
+}
+
+var parseRegExp = new RegExp(_objectValuesToString(regExp));
+
+function parse(content) {
+    content = trim(content);
+
+    // replace Linebreak with Unicode
+    content = content.replace(/\n/g, '\uffff');
+
+    var matches = parseRegExp.exec(content);
+
+    if ( ! matches)
+        return null;
+
+    group = matches[1];
+
+    // Replace Unicode Linebreaks in description
+    if (matches[3])
+        matches[3] = matches[3].replace(/\uffff/g, '\n');
+
+    return {
+        group        : group,
+        type         : matches[2],
+        description  : unindent(matches[3] || '')
+    };
+}
+
+function path() {
+    return 'local.success.statuses.' + getGroup();
+}
+
+function getGroup() {
+    return group;
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse         : parse,
+    path          : path,
+    method        : 'insert',
+    getGroup      : getGroup,
+    markdownFields: [ 'description', 'type' ],
+    markdownRemovePTags: [ 'type' ]
+};


### PR DESCRIPTION
1) Added `@apiSuccessHeader`
Describe response header. Syntax is the same as `@apiParam`
Example: `@apiSuccessHeader (Success 200) {String} version API version`

2) Added `@apiSuccessStatus`
Describes success status group (in particular response without params).

Usage: `@apiSuccessStatus (group) {type} description`
**group** - related success group name, e.g. `Success 200`
**type** optional - response type, e.g. `application/json`, `application/xml`, `text/plain` or `empty` for empty response
**description** optional
